### PR TITLE
Use the ValueString method to get the string value of the packet

### DIFF
--- a/control.go
+++ b/control.go
@@ -80,7 +80,7 @@ func NewControlStringFromPacket(p *ber.Packet) (Control, error) {
 	c := new(ControlString)
 	c.ControlType = controlType
 	c.Criticality = criticality
-	c.ControlValue = value.Value.(string)
+	c.ControlValue = value.ValueString()
 	return c, nil
 }
 
@@ -222,12 +222,12 @@ func ReplaceControl(controls []Control, control Control) (oldControl Control) {
 //	c := new(ControlString)
 //	c.ControlType = controlType
 //	c.Criticality = criticality
-//	c.ControlValue = value.Value.(string)
+//	c.ControlValue = value.ValueString()
 //	return c
 //}
 
 func decodeControlTypeAndCrit(p *ber.Packet) (controlType string, criticality bool, value *ber.Packet) {
-	controlType = p.Children[0].Value.(string)
+	controlType = p.Children[0].ValueString()
 	p.Children[0].Description = "Control Type (" + ControlTypeMap[controlType] + ")"
 	criticality = false
 	if len(p.Children) == 3 {
@@ -580,7 +580,7 @@ func NewControlServerSideSortResponse(p *ber.Packet) (Control, error) {
 
 	if len(value.Children) == 2 {
 		value.Children[1].Description = "Attribute Name"
-		c.AttributeName = value.Children[1].Value.(string)
+		c.AttributeName = value.Children[1].ValueString()
 		value.Children[1].Value = c.AttributeName
 	}
 	return c, nil
@@ -662,7 +662,7 @@ func NewControlVlvResponse(p *ber.Packet) (Control, error) {
 
 	if len(value.Children) == 4 {
 		value.Children[3].Description = "ContextID"
-		c.ContextID = value.Children[3].Value.(string)
+		c.ContextID = value.Children[3].ValueString()
 	}
 
 	return c, nil

--- a/ldap.go
+++ b/ldap.go
@@ -241,7 +241,7 @@ func addControlDescriptions(packet *ber.Packet) {
 	packet.Description = "Controls"
 	for _, child := range packet.Children {
 		child.Description = "Control"
-		child.Children[0].Description = "Control Type (" + ControlTypeMap[child.Children[0].Value.(string)] + ")"
+		child.Children[0].Description = "Control Type (" + ControlTypeMap[child.Children[0].ValueString()] + ")"
 		value := child.Children[1]
 		if len(child.Children) == 3 {
 			child.Children[1].Description = "Criticality"
@@ -249,7 +249,7 @@ func addControlDescriptions(packet *ber.Packet) {
 		}
 		value.Description = "Control Value"
 
-		switch child.Children[0].Value.(string) {
+		switch child.Children[0].ValueString() {
 		case ControlTypePaging:
 			value.Description += " (Paging)"
 			if value.Value != nil {
@@ -319,7 +319,7 @@ func getLDAPResultCode(p *ber.Packet) (code uint8, description string) {
 		response := p.Children[1]
 		if response.ClassType == ber.ClassApplication && response.TagType == ber.TypeConstructed && len(response.Children) == 3 {
 			code = uint8(response.Children[0].Value.(uint64))
-			description = response.Children[2].Value.(string)
+			description = response.Children[2].ValueString()
 			return
 		}
 	}

--- a/search.go
+++ b/search.go
@@ -232,12 +232,12 @@ func decodeSearchResponse(packet *ber.Packet) (discreteSearchResult *DiscreteSea
 	case SearchResultEntry:
 		discreteSearchResult.SearchResultType = SearchResultEntry
 		entry := new(Entry)
-		entry.DN = packet.Children[1].Children[0].Value.(string)
+		entry.DN = packet.Children[1].Children[0].ValueString()
 		for _, child := range packet.Children[1].Children[1].Children {
 			attr := new(EntryAttribute)
-			attr.Name = child.Children[0].Value.(string)
+			attr.Name = child.Children[0].ValueString()
 			for _, value := range child.Children[1].Children {
-				attr.Values = append(attr.Values, value.Value.(string))
+				attr.Values = append(attr.Values, value.ValueString())
 			}
 			entry.Attributes = append(entry.Attributes, attr)
 		}
@@ -253,14 +253,14 @@ func decodeSearchResponse(packet *ber.Packet) (discreteSearchResult *DiscreteSea
 		if len(packet.Children) == 3 {
 			controls := make([]Control, 0)
 			for _, child := range packet.Children[2].Children {
-				// child.Children[0].Value.(string) = control oid
-				decodeFunc, present := ControlDecodeMap[child.Children[0].Value.(string)]
+				// child.Children[0].ValueString() = control oid
+				decodeFunc, present := ControlDecodeMap[child.Children[0].ValueString()]
 				if present {
 					c, _ := decodeFunc(child)
 					controls = append(controls, c)
 				} else {
 					// not fatal but definately a warning
-					log.Println("Couldn't decode Control : " + child.Children[0].Value.(string))
+					log.Println("Couldn't decode Control : " + child.Children[0].ValueString())
 				}
 			}
 			discreteSearchResult.Controls = controls
@@ -269,7 +269,7 @@ func decodeSearchResponse(packet *ber.Packet) (discreteSearchResult *DiscreteSea
 	case SearchResultReference:
 		discreteSearchResult.SearchResultType = SearchResultReference
 		for ref := range packet.Children[1].Children {
-			discreteSearchResult.Referrals = append(discreteSearchResult.Referrals, packet.Children[1].Children[ref].Value.(string))
+			discreteSearchResult.Referrals = append(discreteSearchResult.Referrals, packet.Children[1].Children[ref].ValueString())
 		}
 		return discreteSearchResult, nil
 	}


### PR DESCRIPTION
This allows us to properly handle octet strings in packets, which might
contain UTF-8 encoded strings. Otherwise, UTF-8 encoded strings in the LDAP database are not correctly returned in the search results.

Requires the changes I made to mavricknz/ans1-ber. See the pull request I opened there.
