### PR TITLE
Make moddn operation work.

### DIFF
--- a/moddn.go
+++ b/moddn.go
@@ -48,8 +48,8 @@ func encodeModDnRequest(req *ModDnRequest) (p *ber.Packet) {
 	p.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimative, ber.TagOctetString, req.NewRDN, "NewRDN"))
 	p.AppendChild(ber.NewBoolean(ber.ClassUniversal, ber.TypePrimative, ber.TagBoolean, req.DeleteOldDn, "deleteoldrdn"))
 	if len(req.NewSuperiorDN) > 0 {
-		p.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimative,
-			ber.TagOctetString, req.NewSuperiorDN, "NewSuperiorDN"))
+		p.AppendChild(ber.NewString(ber.ClassContext, ber.TypePrimative,
+			ber.TagEOC, req.NewSuperiorDN, "NewSuperiorDN"))
 	}
 	return
 }


### PR DESCRIPTION
The original code had the field type and tag set incorrectly on the
NewSuperiorDN value: it was marked as a simple string. However the protocol
apparently wants it marked as the Context for the operation. Accordingly,
moddn worked but the server interpreted it as not having a new superior DN
field, meaning it would only ever rename RDNs and never actually move an
entry.

Comparison of packets issued by a working implementation led to this change;
with this change, moddn now works, and honors new superior DN arguments.